### PR TITLE
fix desktop notification layout: add flexbox for icon+text row

### DIFF
--- a/css/notification.css
+++ b/css/notification.css
@@ -24,6 +24,21 @@
   transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
+.notification-row {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.notification-icon {
+  flex: 0 0 auto;
+}
+
+.notification-msg {
+  text-align: left;
+}
+
 /* When "show" is added, fade in */
 .notification.show {
   opacity: 1;


### PR DESCRIPTION
The desktop notification CSS was missing flexbox rules for the .notification-row structure, causing the icon and message to stack vertically instead of displaying inline.