### PR TITLE
feat: add right-click context menus, help popup, and clipboard UX imp…

### DIFF
--- a/css/about-panel.css
+++ b/css/about-panel.css
@@ -5,27 +5,42 @@
   z-index: 3;
 }
 
-#githubLink {
-  font-size: 18px;
-  background: none;
-  padding: 0;
-  margin: 0;
+.about-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
 }
 
-.about-panel-content {
-  display: flex;
+.pill-btn {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-}
-
-.about-label {
-  font-size: 16px;
+  gap: 5px;
+  padding: 4px 14px;
+  font-size: 12px;
+  font-weight: 600;
   color: #d8d4cf;
+  background: #222426;
+  border: 1px solid #3a3c3e;
+  border-radius: 20px;
+  cursor: pointer;
+  white-space: nowrap;
+  width: auto;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
 }
 
-.action-buttons {
-  display: flex;
-  gap: 10px;
+.pill-btn i {
+  font-size: 13px;
 }
 
+.pill-btn:hover {
+  background: #2a2d30;
+  color: #fff;
+  border-color: #5a7a9a;
+}
 
+.pill-btn:hover {
+  background: #444;
+  color: #fff;
+  border-color: #777;
+}

--- a/css/colorset-panel.css
+++ b/css/colorset-panel.css
@@ -3,12 +3,11 @@
   z-index: 3;
 }
 
-#colorset-status {
-  display: flex;
-  justify-content: right;
-  align-items: center;
-  padding: 5px 10px;
-  color: #fff;
+#colorsetDivider {
+  margin-left: 10px;
+  margin-right: 10px;
+  border-color: rgba(0, 0, 0, 0.3);
+  margin-bottom: 0;
 }
 
 #colorset {
@@ -18,14 +17,14 @@
   padding: 10px;
   gap: 6px;
   overflow-x: auto;
-  flex-wrap: nowrap; /* Prevent wrapping */
-  min-height: 52px; /* Consistent container height */
+  flex-wrap: nowrap;
+  min-height: 52px;
 }
 
 /* Color Cube Styling */
 .color-cube {
-  width: 32px; /* Consistent width */
-  height: 32px; /* Consistent height */
+  width: 32px;
+  height: 32px;
   border-radius: 8px;
   background: #333;
   box-shadow: 0 0 10px #222;
@@ -64,63 +63,149 @@
   box-shadow: none;
 }
 
-
-#colorset-randomize {
-  font-size: 22px;
-  padding: 1px;
-  margin-left: 5px;
-  margin-right: 5px;
-}
-
-
-#colorset-controls {
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-  padding: 5px;
-  gap: 10px;
-}
-
-.preset-button {
-  font-size: 22px;
-  width: 32px;
-  height: 32px;
-  border: 2px solid #555;
-  background-size: cover;
-  background-position: center;
+/* Generator section */
+#toggleColorsetGenerator {
+  margin: 0 auto;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  margin-right: 8px;
+  margin-bottom: -10px;
 }
 
-.preset-button:hover {
-  transform: scale(1.1);
-  box-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+#toggleColorsetGenerator:hover {
+  background: transparent;
 }
 
-#colorset-preset-rainbow {
-  background: linear-gradient(135deg, red, orange, yellow, green, blue, indigo, violet);
+#colorsetGenerator {
+  padding: 10px;
 }
-#colorset-preset-grayscale {
-  background: linear-gradient(135deg, #000, #333, #666, #999, #ccc, #eee, #fff);
+
+/* — Colors slider (white/gray, with tick marks) — */
+
+#genNumColors::-webkit-slider-runnable-track {
+  background: 
+    linear-gradient(to right, #ccc var(--slider-fill), #555 var(--slider-fill));
 }
-#colorset-preset-pastel {
-  background: linear-gradient(135deg, #FFB3BA, #FFDFBA, #FFFFBA, #BAFFC9, #BAE1FF);
+
+#genNumColors::-moz-range-track {
+  background: 
+    linear-gradient(to right, #ccc var(--slider-fill), #555 var(--slider-fill));
 }
-#colorset-preset-dark {
-  background: linear-gradient(135deg, #200, #444, #006);
+
+#genNumColors::-webkit-slider-thumb {
+  background: linear-gradient(to bottom, #fff, #bbb);
+  border-color: #999;
 }
-#colorset-preset-one {
-  background: red;
+
+#genNumColors::-moz-range-thumb {
+  background: linear-gradient(to bottom, #fff, #bbb);
+  border-color: #999;
 }
-#colorset-preset-two {
-  background: linear-gradient(90deg, red 50%, #00a2e8 50%);
+
+#genNumColors:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 3px rgba(150, 150, 150, 0.4);
 }
-#colorset-preset-three {
-  background: linear-gradient(90deg, red 0%, red 33.33%, green 33.33%, green 66.66%, #00a2e8 66.66%, #00a2e8 100%);
+
+#genNumColors:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 3px rgba(150, 150, 150, 0.4);
 }
-#colorset-preset-four {
-  background: linear-gradient(90deg, red 0%, red 25%, green 25%, green 50%, #00a2e8 50%, #00a2e8 75%, orange 75%, orange 100%);
+
+/* — Brightness slider (yellowish) — */
+
+#genBrightness::-webkit-slider-runnable-track {
+  background: linear-gradient(to right, #e8b830 var(--slider-fill), #555 var(--slider-fill));
+}
+
+#genBrightness::-moz-range-track {
+  background: linear-gradient(to right, #e8b830 var(--slider-fill), #555 var(--slider-fill));
+}
+
+#genBrightness::-webkit-slider-thumb {
+  background: linear-gradient(to bottom, #f5d060, #d4a020);
+  border-color: #e8b830;
+}
+
+#genBrightness::-moz-range-thumb {
+  background: linear-gradient(to bottom, #f5d060, #d4a020);
+  border-color: #e8b830;
+}
+
+#genBrightness:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 3px rgba(232, 184, 48, 0.4);
+}
+
+#genBrightness:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 3px rgba(232, 184, 48, 0.4);
+}
+
+#colorsetGenerator .control-input {
+  border-color: #555;
+  color: #e8e4df;
+}
+
+#colorsetGenerator .control-input:focus {
+  border-color: #cc4400;
+  background: #2a2d30;
+}
+
+.gen-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.gen-label {
+  color: #d8d4cf;
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  flex: 0 0 auto;
+  min-width: 60px;
+}
+
+.gen-half {
+  flex: 0 0 calc(50% - 4px);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.gen-select {
+  background: #222426;
+  color: #d8d4cf;
+  border: 1px solid #3a3c3e;
+  border-radius: 3px;
+  padding: 3px 6px;
+  font-size: 12px;
+  flex: 1;
+  min-width: 0;
+  height: 22px;
+}
+
+.gen-select:focus {
+  outline: none;
+  border-color: #5a7a9a;
+}
+
+.gen-button {
+  display: block;
+  width: 100%;
+  padding: 8px 0;
+  font-size: 14px;
+  font-weight: bold;
+  color: #fff;
+  background: #cc4400;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.gen-button:hover {
+  background: #dd5500;
+}
+
+.hidden {
+  display: none;
 }
 
 .colorset-empty-label {
@@ -128,6 +213,5 @@
   color: #454545;
   font-size: 24px;
   margin: 0 auto;
-  display: none; /* Initially hidden */
+  display: none;
 }
-

--- a/css/context-menu.css
+++ b/css/context-menu.css
@@ -1,0 +1,100 @@
+/* context-menu.css */
+.context-menu {
+  position: fixed;
+  z-index: 10000;
+  background: #2a2a2a;
+  border: 1px solid #555;
+  border-radius: 6px;
+  padding: 4px 0;
+  min-width: 180px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.6);
+}
+
+.context-menu-item {
+  padding: 8px 16px;
+  color: #e0ddd9;
+  font-size: 14px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s;
+}
+
+.context-menu-item:hover {
+  background-color: #3a6ea5;
+  color: #fff;
+}
+
+.context-menu-item.disabled {
+  color: #666;
+  cursor: default;
+}
+
+.context-menu-item.disabled:hover {
+  background-color: transparent;
+  color: #666;
+}
+
+.context-menu-item.danger {
+  color: #e07474;
+}
+
+.context-menu-item.danger:hover {
+  background-color: #8b3a3a;
+  color: #fff;
+}
+
+.context-menu-separator {
+  height: 1px;
+  background: #444;
+  margin: 4px 8px;
+}
+
+/* Help popup */
+.help-popup-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 20000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.help-popup {
+  width: min(95vw, 400px);
+  height: auto;
+  background: #1e1e1e;
+  border: 1px solid #555;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+
+.help-popup-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px;
+  background: #2a2a2a;
+  border-bottom: 1px solid #444;
+  font-size: 16px;
+  font-weight: bold;
+  color: #e0ddd9;
+}
+
+.help-popup-close {
+  cursor: pointer;
+  font-size: 22px;
+  color: #999;
+  line-height: 1;
+}
+
+.help-popup-close:hover {
+  color: #fff;
+}
+

--- a/css/modes-panel.css
+++ b/css/modes-panel.css
@@ -128,18 +128,20 @@
 }
 
 .delete-mode-btn {
-  position: relative;
-  top: -4px; /* it's a button so it has extra space on the top */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background-color: transparent;
   border: none;
   color: #aaa;
-  float: right;
-  font-size: 32px;
+  font-size: 28px;
   font-weight: bold;
   user-select: none;
   width: auto;
   margin: 0;
-  padding: 1px 6px;
+  padding: 0 6px;
+  position: relative;
+  top: -3px;
 }
 
 .delete-mode-btn:hover, .delete-mode-btn:focus {

--- a/css/styles.css
+++ b/css/styles.css
@@ -16,3 +16,4 @@
 @import url('welcome-panel.css');
 @import url('pattern-panel.css');
 @import url('community-browser-panel.css');
+@import url('context-menu.css');

--- a/css/vortex-editor.css
+++ b/css/vortex-editor.css
@@ -58,15 +58,14 @@ i {
   height: 32px;
   border: none;
   border-radius: 4px;
-  background-color: #333;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   background: none;
   color: inherit;
   font-size: 20px;
   cursor: pointer;
-  padding: 5px;
-  transition: background-color 0.2s;
+  padding: 0;
   transition: transform 0.2s, color 0.2s;
 }
 

--- a/css/welcome-panel.css
+++ b/css/welcome-panel.css
@@ -16,6 +16,33 @@
   width: 16px;
 }
 
+#welcomePanel .welcome-title {
+  font-size: 36px;
+  font-weight: 900;
+  text-align: center;
+  background: linear-gradient(135deg, #ff6600, #ffcc00, #ff6600);
+  background-size: 200% 200%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: bannerShimmer 3s ease-in-out infinite;
+  text-shadow: none;
+  margin-bottom: 20px;
+  letter-spacing: 1px;
+}
+
+#welcomePanel .intro-text {
+  font-size: 20px;
+  line-height: 1.6;
+  color: #c8c4c0;
+  margin: 0 50px 8px;
+  text-align: center;
+}
+
+#welcomePanel .intro-text:last-of-type {
+  margin: 0 50px 20px;
+}
+
 #welcomePanel p {
   font-size: 20px;
 }
@@ -25,6 +52,102 @@
 }
 
 /* public/css/components/welcome-panel.css */
+
+.features-container {
+  border: 1px solid #444;
+  border-radius: 10px;
+  margin: 16px 0;
+  overflow: hidden;
+}
+
+.features-container-title {
+  background: linear-gradient(135deg, #3a3a3a, #4a4a4a);
+  color: #f0ece8;
+  font-size: 17px;
+  font-weight: 700;
+  text-align: center;
+  padding: 9px 0;
+  letter-spacing: 1px;
+  border-bottom: 1px solid #555;
+}
+
+.feature-scroll {
+  max-height: 340px;
+  overflow-y: auto;
+  padding: 8px 10px;
+  scrollbar-color: #777 transparent;
+}
+
+.feature-scroll::-webkit-scrollbar {
+  width: 10px;
+}
+.feature-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.feature-scroll::-webkit-scrollbar-thumb {
+  background: #666;
+  border-radius: 5px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+.feature-scroll::-webkit-scrollbar-thumb:hover {
+  background: #888;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+.feature-box {
+  background: #2a2a2a;
+  border: 1px solid #555;
+  border-left: 4px solid #ff4400;
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin: 10px 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  cursor: pointer;
+}
+
+.feature-box.seen {
+  border-left-color: #555;
+  cursor: default;
+}
+
+.feature-box:not(.seen):hover {
+  border-color: #ff6600;
+  box-shadow: 0 0 12px rgba(255, 68, 0, 0.25);
+}
+
+.feature-badge {
+  background: #ff4400;
+  color: #fff;
+  font-size: 11px;
+  font-weight: bold;
+  padding: 3px 8px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.feature-badge.pulse {
+  animation: badgePulse 2s ease-in-out infinite;
+}
+
+@keyframes badgePulse {
+  0%, 100% {
+    background: #ff4400;
+    box-shadow: 0 0 6px rgba(255, 68, 0, 0.4);
+  }
+  50% {
+    background: #ff6600;
+    box-shadow: 0 0 14px rgba(255, 68, 0, 0.8);
+  }
+}
+
 .wiki-button {
   display: inline-flex;
   align-items: center;
@@ -37,7 +160,7 @@
   background-color: #28a745; /* Green color */
   border-radius: 8px;
   transition: background-color 0.3s ease, transform 0.2s ease;
-  margin: 20px 0;
+  margin: 18px 0 0;
 }
 
 .wiki-button .arrow {
@@ -55,12 +178,33 @@
   transform: translateY(1px);
 }
 
+.close-welcome-btn {
+  display: block;
+  width: auto;
+  min-width: 120px;
+  margin: 18px auto 0;
+  padding: 10px 24px;
+  font-size: 15px;
+  font-weight: bold;
+  color: #ccc;
+  background: #3a3a3a;
+  border: 1px solid #555;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.close-welcome-btn:hover {
+  background: #4a4a4a;
+  color: #fff;
+}
+
 /* Container for the checkbox to help with positioning */
 .checkbox-container {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-top: 20px; /* Adjust the margin to position it lower */
+  margin-top: 18px;
 }
 
 /* Label for the checkbox */

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Lightshowz lol</title>
+    <style>html,body{background-color:#181a1b;margin:0}</style>
     <script type="module" src="js/Main.js"></script>
   </head>
   <body>

--- a/js/AboutPanel.js
+++ b/js/AboutPanel.js
@@ -1,50 +1,55 @@
 import Panel from './Panel.js';
 
+const COMMUNITY_URL = 'https://vortex.community';
+const GITHUB_URL = 'https://github.com/StoneOrbits/VortexEngine';
+const WIKI_URL = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/';
+
 export default class AboutPanel extends Panel {
   constructor(editor) {
     const content = `
-      <div class="about-panel-content">
-        <label class="about-label">Made with Vortex Engine</label>
-        <div class="action-buttons">
-          <button id="githubLinkButton" class="icon-button" aria-label="View on Github">
-            <i class="fab fa-github" title="View on Github"></i>
-          </button>
-          <button id="patternHelpButton" class="icon-button" aria-label="Help">
-            <i class="fas fa-question-circle" title="Help"></i>
-          </button>
-        </div>
+      <div class="about-pills">
+        <button id="communityButton" class="pill-btn">
+          <i class="fas fa-globe"></i> Community
+        </button>
+        <button id="githubLinkButton" class="pill-btn">
+          <i class="fab fa-github"></i> GitHub
+        </button>
+        <button id="whatsNewButton" class="pill-btn">
+          <i class="fas fa-star"></i> Welcome
+        </button>
       </div>
     `;
     super(editor, 'aboutPanel', content, 'Help & About');
     this.editor = editor;
+    this.wikiUrl = WIKI_URL;
     this.lightshow = editor.lightshow;
     this.vortexPort = editor.vortexPort;
   }
 
-  initialize() {
-    this.addClickListener('patternHelpButton', this.showHelp);
+  async initialize() {
+    this.addClickListener('communityButton', this.gotoCommunity);
     this.addClickListener('githubLinkButton', this.gotoGithub);
+    this.addClickListener('whatsNewButton', this.showWhatsNew);
   }
 
   destroy() {
-    this.removeClickListener('patternHelpButton', this.showHelp);
+    this.removeClickListener('communityButton', this.gotoCommunity);
     this.removeClickListener('githubLinkButton', this.gotoGithub);
+    this.removeClickListener('whatsNewButton', this.showWhatsNew);
+  }
+
+  showWhatsNew() {
+    if (this.editor && this.editor.welcomePanel) {
+      this.editor.welcomePanel.show();
+    }
+  }
+
+  gotoCommunity() {
+    window.open(COMMUNITY_URL, '_blank');
   }
 
   gotoGithub() {
-    try {
-      window.open("https://github.com/StoneOrbits/VortexEngine", '_blank').focus();
-    } catch (error) {
-      console.error("Could not open GitHub link:", error);
-    }
-  }
-
-  showHelp() {
-    try {
-      window.open("https://stoneorbits.github.io/VortexEngine/lightshow_lol.html", '_blank').focus();
-    } catch (error) {
-      console.error("Could not open help link:", error);
-    }
+    window.open(GITHUB_URL, '_blank');
   }
 }
 

--- a/js/AnimationPanel.js
+++ b/js/AnimationPanel.js
@@ -98,6 +98,7 @@ export default class AnimationPanel extends Panel {
     super(editor, 'animationPanel', content, 'Animation');
 
     this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/animation';
     this.lightshow = editor.lightshow;
     this.controls = controls;
     this.isVisible = true;
@@ -142,6 +143,10 @@ export default class AnimationPanel extends Panel {
           const element = this.panel.querySelector(`#${id}`);
           element.value = value;
           control.update(value);
+          const min = parseFloat(element.min);
+          const max = parseFloat(element.max);
+          const percent = ((parseFloat(value) - min) / (max - min)) * 100;
+          element.style.setProperty('--slider-fill', `${percent}%`);
         }
       });
     }

--- a/js/ChromalinkPanel.js
+++ b/js/ChromalinkPanel.js
@@ -29,6 +29,7 @@ export default class ChromalinkPanel extends Panel {
     `;
     super(editor, 'chromalinkPanel', content, 'Chromalink Duo');
     this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/chromalink-duo';
     this.vortexPort = editor.vortexPort;
     this.isConnected = false;
     this.confirmationModal = new Modal('duo-flash-confirmation');

--- a/js/ColorPickerPanel.js
+++ b/js/ColorPickerPanel.js
@@ -4,6 +4,7 @@ export default class ColorPickerPanel extends Panel {
   constructor(editor) {
     super(editor, 'colorPickerPanel', '', 'Color Picker', { showCloseButton: true }); // Pass id and title to Panel
     this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/color-picker';
     this.lightshow = editor.lightshow;
     this.selectedIndex = 0;
     this.colorState = { r: 255, g: 0, b: 0, h: 0, s: 255, v: 255 };

--- a/js/ColorsetPanel.js
+++ b/js/ColorsetPanel.js
@@ -2,27 +2,50 @@ import Panel from './Panel.js';
 import Modal from './Modal.js';
 import Notification from './Notification.js';
 import ColorPickerPanel from './ColorPickerPanel.js';
+import ContextMenu from './ContextMenu.js';
 
 export default class ColorsetPanel extends Panel {
   constructor(editor) {
-    //<div id="colorset-selected-leds" class="selected-leds-bar"></div>
     const content = `
-      <div id="colorset-status" style="display: ${editor.detectMobile() ? 'none' : ''};">
-        <button id="colorset-preset-one" class="preset-button" title="Randomize One Color"></button>
-        <button id="colorset-preset-two" class="preset-button" title="Randomize Two Colors"></button>
-        <button id="colorset-preset-three" class="preset-button" title="Randomize Three Colors"></button>
-        <button id="colorset-preset-four" class="preset-button" title="Randomize Four Colors"></button>
-        <button id="colorset-preset-rainbow" class="preset-button" title="Randomize Rainbow"></button>
-        <button id="colorset-preset-grayscale" class="preset-button" title="Randomize Grayscale"></button>
-        <button id="colorset-preset-pastel" class="preset-button" title="Randomize Pastels"></button>
-        <button id="colorset-preset-dark" class="preset-button" title="Randomize Dark Colors"></button>
-      </div>
-      <hr id="patternDivider" style="display: ${editor.detectMobile() ? 'none' : ''};">
       <div id="colorset" class="color-row"></div>
+      <hr id="colorsetDivider">
+      <button id="toggleColorsetGenerator" class="icon-button" title="Show/Hide Generator">
+        <i class="fa-solid fa-chevron-down"></i>
+      </button>
+      <div id="colorsetGenerator" class="hidden">
+        <div class="gen-row">
+          <div class="gen-half">
+            <input type="range" id="genNumColors" class="control-slider" min="1" max="8" value="8">
+            <input type="number" id="genNumColorsInput" class="control-input" value="8" min="1" max="8">
+          </div>
+          <div class="gen-half">
+            <span class="gen-label" style="min-width:auto;">Style</span>
+            <select id="genStyle" class="gen-select">
+              <option value="rainbow">Rainbow</option>
+              <option value="random">Random</option>
+              <option value="pastel">Pastel</option>
+              <option value="dark">Dark</option>
+              <option value="grayscale">Grayscale</option>
+              <option value="vibrant">Vibrant</option>
+              <option value="warm">Warm</option>
+              <option value="cool">Cool</option>
+            </select>
+          </div>
+        </div>
+        <div class="gen-row">
+          <span class="gen-label">Brightness</span>
+          <div class="control-slider-container">
+            <input type="range" id="genBrightness" class="control-slider" min="10" max="100" value="100">
+          </div>
+          <input type="number" id="genBrightnessInput" class="control-input" value="100" min="10" max="100">
+        </div>
+        <button id="generateColorsetBtn" class="gen-button">Generate</button>
+      </div>
       <div id="colorPickerMountMobile" style="display: ${editor.detectMobile() ? 'block' : 'none'};"></div>
     `;
     super(editor, 'colorsetPanel', content, 'Colorset');
     this.editor = editor
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/colorset';
     this.lightshow = editor.lightshow;
     this.vortexPort = editor.vortexPort;
     this.selectedColorIndex = null;
@@ -31,16 +54,80 @@ export default class ColorsetPanel extends Panel {
 
   initialize() {
     this.refresh();
-    // Add event listeners for preset buttons
-    document.getElementById('colorset-preset-rainbow').addEventListener('click', () => this.applyPreset('rainbow'));
-    document.getElementById('colorset-preset-grayscale').addEventListener('click', () => this.applyPreset('grayscale'));
-    document.getElementById('colorset-preset-pastel').addEventListener('click', () => this.applyPreset('pastel'));
-    document.getElementById('colorset-preset-dark').addEventListener('click', () => this.applyPreset('dark'));
-    document.getElementById('colorset-preset-one').addEventListener('click', () => this.applyPreset('one'));
-    document.getElementById('colorset-preset-two').addEventListener('click', () => this.applyPreset('two'));
-    document.getElementById('colorset-preset-three').addEventListener('click', () => this.applyPreset('three'));
-    document.getElementById('colorset-preset-four').addEventListener('click', () => this.applyPreset('four'));
-    // Listen for the modeChange event
+
+    document.getElementById('toggleColorsetGenerator').addEventListener('click', () => this.toggleGenerator());
+    document.getElementById('generateColorsetBtn').addEventListener('click', () => this.generateColorset());
+
+    const setupSlider = (slider, input, min, max, fillParent) => {
+      const range = max - min;
+      const updateFill = () => { fillParent.style.setProperty('--slider-fill', `${((parseInt(slider.value, 10) - min) / range) * 100}%`); };
+      const setValue = (clientX) => {
+        const rect = slider.getBoundingClientRect();
+        let val = Math.round(((clientX - rect.left) / rect.width) * range) + min;
+        val = Math.max(min, Math.min(max, val));
+        slider.value = val;
+        input.value = val;
+        updateFill();
+      };
+
+      let dragActive = false;
+      const onDragEnd = () => {
+        if (!dragActive) return;
+        dragActive = false;
+        document.removeEventListener('mousemove', onDragMove);
+        document.removeEventListener('mouseup', onDragEnd);
+      };
+      const onDragMove = (e) => {
+        if (!dragActive) return;
+        e.preventDefault();
+        setValue(e.clientX);
+      };
+
+      slider.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        setValue(e.clientX);
+        dragActive = true;
+        document.addEventListener('mousemove', onDragMove);
+        document.addEventListener('mouseup', onDragEnd);
+      });
+
+      slider.addEventListener('input', () => {
+        if (dragActive) return;
+        input.value = slider.value;
+        updateFill();
+      });
+
+      slider.addEventListener('change', () => {
+        input.value = slider.value;
+        updateFill();
+      });
+
+      input.addEventListener('input', () => {
+        let v = parseInt(input.value, 10);
+        if (isNaN(v)) v = min;
+        v = Math.max(min, Math.min(max, v));
+        input.value = v;
+        slider.value = v;
+        updateFill();
+      });
+
+      updateFill();
+    };
+
+    setupSlider(
+      document.getElementById('genNumColors'),
+      document.getElementById('genNumColorsInput'),
+      1, 8,
+      document.getElementById('genNumColors').parentElement
+    );
+
+    setupSlider(
+      document.getElementById('genBrightness'),
+      document.getElementById('genBrightnessInput'),
+      10, 100,
+      document.getElementById('genBrightness').parentElement
+    );
+
     document.addEventListener('modeChange', (event) => {
       console.log(`${this.panel.title} Handling: [${event.type}]`);
       this.refresh();
@@ -52,6 +139,36 @@ export default class ColorsetPanel extends Panel {
     });
   }
 
+  toggleGenerator() {
+    const panel = document.getElementById('colorsetPanel');
+    const gen = document.getElementById('colorsetGenerator');
+    const btn = document.getElementById('toggleColorsetGenerator');
+    const icon = btn.querySelector('i');
+
+    const previousHeight = panel.offsetHeight;
+    const snappedPanels = this.getSnappedPanels();
+
+    const isHidden = gen.classList.toggle('hidden');
+    icon.classList.toggle('fa-chevron-down', isHidden);
+    icon.classList.toggle('fa-chevron-up', !isHidden);
+
+    const heightChange = panel.offsetHeight - previousHeight;
+    snappedPanels.forEach((otherPanel) => {
+      otherPanel.moveSnappedPanels(heightChange);
+      const currentTop = parseFloat(otherPanel.panel.style.top || otherPanel.panel.getBoundingClientRect().top);
+      otherPanel.panel.style.top = `${currentTop + heightChange}px`;
+    });
+  }
+
+  generateColorset() {
+    const numColors = parseInt(document.getElementById('genNumColors').value, 10);
+    const style = document.getElementById('genStyle').value;
+    const brightness = parseInt(document.getElementById('genBrightness').value, 10);
+    const styles = ['rainbow', 'pastel', 'dark', 'vibrant', 'warm', 'cool', 'grayscale'];
+    const actualStyle = style === 'random' ? styles[Math.floor(Math.random() * styles.length)] : style;
+    this.applyPreset(actualStyle, numColors, brightness);
+  }
+
   getTargetLeds() {
     return this.editor.ledSelectPanel.getSelectedLeds();
   }
@@ -60,76 +177,100 @@ export default class ColorsetPanel extends Panel {
     return this.editor.ledSelectPanel.getMainSelectedLed();
   }
 
-  applyPreset(preset) {
+  applyPreset(preset, numColors, brightness = 100) {
     const cur = this.lightshow.vortex.engine().modes().curMode();
     if (!cur) return;
 
     const set = cur.getColorset(this.getMainSelectedLed());
     set.clear();
-    let numCols = ((Math.random() * 100) % 8);
 
     switch (preset) {
     case 'rainbow':
-      if (numCols < 5) {
-        numCols = 4 + (numCols % 4);
-      }
-      for (let i = 0; i < numCols; i++) {
-        const hue = (i / numCols) * 360;
-        const rgb = this.hslToRgb(hue, 1, 0.5); // Full saturation, medium lightness
+      for (let i = 0; i < numColors; i++) {
+        const hue = (i / numColors) * 360;
+        const rgb = this.hslToRgb(hue, 1, 0.5);
         set.addColor(new this.lightshow.vortexLib.RGBColor(rgb.r, rgb.g, rgb.b));
       }
       break;
     case 'grayscale':
-      for (let i = 0; i < numCols; i++) {
+      for (let i = 0; i < numColors; i++) {
         const gray = Math.floor(Math.random() * 256);
         set.addColor(new this.lightshow.vortexLib.RGBColor(gray, gray, gray));
       }
       break;
     case 'pastel':
-      for (let i = 0; i < numCols; i++) {
-        const pastel = {
+      for (let i = 0; i < numColors; i++) {
+        const c = {
           r: Math.floor(Math.random() * 128 + 127),
           g: Math.floor(Math.random() * 128 + 127),
           b: Math.floor(Math.random() * 128 + 127),
         };
-        set.addColor(new this.lightshow.vortexLib.RGBColor(pastel.r, pastel.g, pastel.b));
+        set.addColor(new this.lightshow.vortexLib.RGBColor(c.r, c.g, c.b));
       }
       break;
     case 'dark':
-      for (let i = 0; i < numCols; i++) {
-        const dark = {
+      for (let i = 0; i < numColors; i++) {
+        const c = {
           r: Math.floor(Math.random() * 128),
           g: Math.floor(Math.random() * 128),
           b: Math.floor(Math.random() * 128),
         };
-        set.addColor(new this.lightshow.vortexLib.RGBColor(dark.r, dark.g, dark.b));
+        set.addColor(new this.lightshow.vortexLib.RGBColor(c.r, c.g, c.b));
       }
       break;
-    case 'one':
-      const color = this.getRandomColor();
-      set.addColor(new this.lightshow.vortexLib.RGBColor(color.r, color.g, color.b));
-      break;
-    case 'two':
-      for (let i = 0; i < 2; i++) {
-        const color = this.getRandomColor();
-        set.addColor(new this.lightshow.vortexLib.RGBColor(color.r, color.g, color.b));
+    case 'vibrant':
+      for (let i = 0; i < numColors; i++) {
+        const c = {
+          r: Math.random() < 0.5 ? Math.floor(Math.random() * 128 + 128) : Math.floor(Math.random() * 56),
+          g: Math.random() < 0.5 ? Math.floor(Math.random() * 128 + 128) : Math.floor(Math.random() * 56),
+          b: Math.random() < 0.5 ? Math.floor(Math.random() * 128 + 128) : Math.floor(Math.random() * 56),
+        };
+        set.addColor(new this.lightshow.vortexLib.RGBColor(c.r, c.g, c.b));
       }
       break;
-    case 'three':
-      for (let i = 0; i < 3; i++) {
-        const color = this.getRandomColor();
-        set.addColor(new this.lightshow.vortexLib.RGBColor(color.r, color.g, color.b));
+    case 'warm':
+      for (let i = 0; i < numColors; i++) {
+        const c = {
+          r: Math.floor(Math.random() * 128 + 128),
+          g: Math.floor(Math.random() * 128),
+          b: Math.floor(Math.random() * 64),
+        };
+        set.addColor(new this.lightshow.vortexLib.RGBColor(c.r, c.g, c.b));
       }
       break;
-    case 'four':
-      for (let i = 0; i < 4; i++) {
-        const color = this.getRandomColor();
-        set.addColor(new this.lightshow.vortexLib.RGBColor(color.r, color.g, color.b));
+    case 'cool':
+      for (let i = 0; i < numColors; i++) {
+        const c = {
+          r: Math.floor(Math.random() * 64),
+          g: Math.floor(Math.random() * 128 + 64),
+          b: Math.floor(Math.random() * 128 + 128),
+        };
+        set.addColor(new this.lightshow.vortexLib.RGBColor(c.r, c.g, c.b));
       }
       break;
     default:
+      for (let i = 0; i < numColors; i++) {
+        const c = this.getRandomColor();
+        set.addColor(new this.lightshow.vortexLib.RGBColor(c.r, c.g, c.b));
+      }
       break;
     }
+
+    if (brightness < 100) {
+      const scale = brightness / 100;
+      const cols = [];
+      for (let i = 0; i < set.numColors(); i++) {
+        const c = set.get(i);
+        cols.push(new this.lightshow.vortexLib.RGBColor(
+          Math.round(c.red * scale),
+          Math.round(c.green * scale),
+          Math.round(c.blue * scale)
+        ));
+      }
+      set.clear();
+      cols.forEach(c => set.addColor(c));
+    }
+
     for (let i = 0; i < this.getTargetLeds().length; ++i) {
       cur.setColorset(set, this.getTargetLeds()[i]);
     }
@@ -233,31 +374,38 @@ export default class ColorsetPanel extends Panel {
   // Paste color from clipboard
   paste() {
     navigator.clipboard.readText().then((hexValue) => {
-      if (!/^#?[0-9A-Fa-f]{6}$/.test(hexValue)) {
-        Notification.failure("Invalid color format");
-        return;
-      }
-
-      const cur = this.lightshow.vortex.engine().modes().curMode();
-      if (!cur) return;
-
-      const set = cur.getColorset(this.getMainSelectedLed());
-      if (!set || this.selectedColorIndex >= set.numColors()) return;
-
-      const { r, g, b } = this.hexToRGB(hexValue);
-      const newColor = new this.lightshow.vortexLib.RGBColor(r, g, b);
-
-      set.set(this.selectedColorIndex, newColor);
-      this.getTargetLeds().forEach(led => cur.setColorset(set, led));
-
-      cur.init();
-      this.lightshow.vortex.engine().modes().saveCurMode();
-      this.refresh();
-
-      Notification.success("Pasted color successfully");
+      this.pasteText(hexValue);
     }).catch(() => {
       Notification.failure("Failed to paste color");
     });
+  }
+
+  pasteText(data) {
+    if (!data) return;
+    if (!/^#?[0-9A-Fa-f]{6}$/.test(data)) {
+      if (this.editor.modesPanel) {
+        this.editor.modesPanel.pasteText(data);
+      }
+      return;
+    }
+
+    const cur = this.lightshow.vortex.engine().modes().curMode();
+    if (!cur) return;
+
+    const set = cur.getColorset(this.getMainSelectedLed());
+    if (!set || this.selectedColorIndex >= set.numColors()) return;
+
+    const { r, g, b } = this.hexToRGB(data);
+    const newColor = new this.lightshow.vortexLib.RGBColor(r, g, b);
+
+    set.set(this.selectedColorIndex, newColor);
+    this.getTargetLeds().forEach(led => cur.setColorset(set, led));
+
+    cur.init();
+    this.lightshow.vortex.engine().modes().saveCurMode();
+    this.refresh();
+
+    Notification.success("Pasted color successfully");
   }
 
   showEmptyPanel() {
@@ -481,10 +629,34 @@ export default class ColorsetPanel extends Panel {
           });
         }
 
-        // Right-click to delete
+        // Right-click context menu
         container.addEventListener('contextmenu', (e) => {
           e.preventDefault();
-          this.delColor(i);
+          e.stopPropagation();
+          this.selectColor(i, container);
+          const menu = ContextMenu.getInstance();
+          menu.show(e.clientX, e.clientY, [
+            {
+              label: 'Copy Color',
+              action: () => this.copy()
+            },
+            { separator: true },
+            {
+              label: 'Delete Color',
+              danger: true,
+              action: () => this.delColor(i)
+            },
+            { separator: true },
+            {
+              label: 'Paste',
+              action: () => this.paste()
+            },
+            { separator: true },
+            {
+              label: 'Help',
+              action: () => this.editor && this.editor.showHelpPopup(this.wikiUrl)
+            }
+          ]);
         });
 
         container.addEventListener('pointerdown', handlePointerDown);
@@ -596,6 +768,14 @@ export default class ColorsetPanel extends Panel {
 
     mount.innerHTML = '';
     mount.appendChild(wrapper);
+  }
+
+  getCopyOptions() {
+    if (this.selectedColorIndex === null) return [];
+    return [{
+      label: 'Copy Color',
+      action: () => this.copy()
+    }];
   }
 
   onActive() {

--- a/js/CommunityBrowserPanel.js
+++ b/js/CommunityBrowserPanel.js
@@ -20,6 +20,7 @@ export default class CommunityBrowserPanel extends Panel {
     `;
     super(editor, 'communityBrowserPanel', initialHTML, 'Community Modes');
     this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/vortex-community/';
     this.lightshow = editor.lightshow;
     this.vortexPort = editor.vortexPort;
 

--- a/js/ContextMenu.js
+++ b/js/ContextMenu.js
@@ -1,0 +1,90 @@
+/* ContextMenu.js */
+export default class ContextMenu {
+  static instance = null;
+
+  constructor() {
+    if (ContextMenu.instance) {
+      return ContextMenu.instance;
+    }
+    this.element = null;
+    ContextMenu.lastMouseX = 0;
+    ContextMenu.lastMouseY = 0;
+    this.setupGlobalListeners();
+    ContextMenu.instance = this;
+  }
+
+  static getInstance() {
+    if (!ContextMenu.instance) {
+      new ContextMenu();
+    }
+    return ContextMenu.instance;
+  }
+
+  show(x, y, items) {
+    this.hide();
+
+    this.element = document.createElement('div');
+    this.element.className = 'context-menu';
+
+    items.forEach(item => {
+      if (item.separator) {
+        const divider = document.createElement('div');
+        divider.className = 'context-menu-separator';
+        this.element.appendChild(divider);
+        return;
+      }
+      const menuItem = document.createElement('div');
+      menuItem.className = 'context-menu-item';
+      if (item.danger) {
+        menuItem.classList.add('danger');
+      }
+      if (item.disabled) {
+        menuItem.classList.add('disabled');
+      }
+      menuItem.textContent = item.label;
+      if (!item.disabled && item.action) {
+        menuItem.addEventListener('click', (e) => {
+          e.stopPropagation();
+          this.hide();
+          item.action();
+        });
+      }
+      this.element.appendChild(menuItem);
+    });
+
+    document.body.appendChild(this.element);
+
+    const rect = this.element.getBoundingClientRect();
+    let left = x;
+    let top = y;
+    if (rect.right > window.innerWidth) {
+      left = window.innerWidth - rect.width - 5;
+    }
+    if (rect.bottom > window.innerHeight) {
+      top = window.innerHeight - rect.height - 5;
+    }
+    this.element.style.left = `${left}px`;
+    this.element.style.top = `${top}px`;
+  }
+
+  hide() {
+    if (this.element) {
+      this.element.remove();
+      this.element = null;
+    }
+  }
+
+  setupGlobalListeners() {
+    document.addEventListener('mousemove', (e) => {
+      ContextMenu.lastMouseX = e.clientX;
+      ContextMenu.lastMouseY = e.clientY;
+    });
+    document.addEventListener('click', () => this.hide(), true);
+    document.addEventListener('contextmenu', () => this.hide(), true);
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        this.hide();
+      }
+    });
+  }
+}

--- a/js/DevicePanel.js
+++ b/js/DevicePanel.js
@@ -51,6 +51,7 @@ export default class DevicePanel extends Panel {
             // </div>
     super(editor, 'devicePanel', content, editor.detectMobile() ? 'Device' : 'Device Controls');
     this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/device-controls';
     this.selectedDevice = 'None';
     this.multiLedWarningModal = new Modal('multiLedWarning');
   }

--- a/js/DuoEditorPanel.js
+++ b/js/DuoEditorPanel.js
@@ -26,6 +26,7 @@ export default class DuoEditorPanel extends Panel {
     `;
     super(editor, 'duoEditorPanel', content, 'Duo Editor');
     this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/chromalink-duo';
     this.selectedLeds = ['0']; // LED 0 selected by default
     this.mainSelectedLed = '0';
   }

--- a/js/LedSelectPanel.js
+++ b/js/LedSelectPanel.js
@@ -42,13 +42,36 @@ export default class LedSelectPanel extends Panel {
     `;
     super(editor, 'ledSelectPanel', content, editor.detectMobile() ? 'LEDs' : 'LED Selection');
     this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/led-selection';
   }
 
   initialize() {
     // Event listeners for LED list and controls
     const ledList = document.getElementById('ledList');
-    ledList.addEventListener('change', () => this.handleLedSelectionChange());
-    ledList.addEventListener('click', () => this.handleLedSelectionChange());
+    ledList.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+    });
+    ledList.addEventListener('click', (e) => {
+      const option = e.target;
+      if (option.tagName !== 'OPTION') return;
+      const isCtrl = e.ctrlKey || e.metaKey;
+      const isShift = e.shiftKey;
+      const clickedIdx = Array.from(ledList.options).indexOf(option);
+      if (isShift && this._lastLedListClickIdx !== undefined) {
+        const lo = Math.min(this._lastLedListClickIdx, clickedIdx);
+        const hi = Math.max(this._lastLedListClickIdx, clickedIdx);
+        for (let i = 0; i < ledList.options.length; i++) {
+          ledList.options[i].selected = (i >= lo && i <= hi);
+        }
+      } else if (isCtrl) {
+        option.selected = !option.selected;
+      } else {
+        for (let o of ledList.options) o.selected = false;
+        option.selected = true;
+      }
+      this._lastLedListClickIdx = clickedIdx;
+      this.handleLedSelectionChange();
+    });
 
     document.getElementById('selectAllLeds').addEventListener('click', () => this.selectAllLeds());
     document.getElementById('selectNoneLeds').addEventListener('click', () => this.selectNoneLeds());

--- a/js/ModesPanel.js
+++ b/js/ModesPanel.js
@@ -36,6 +36,7 @@ export default class ModesPanel extends Panel {
     `;
     super(editor, 'modesPanel', content, editor.detectMobile() ? 'Modes' : 'Modes List');
     this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/modes-list';
     this.lightshow = editor.lightshow;
     this.vortexPort = editor.vortexPort;
     this.shareModal = new Modal('share');
@@ -335,7 +336,13 @@ export default class ModesPanel extends Panel {
 
   // Copy selected mode data
   copy() {
-    if (this.selectedModeIndex === undefined) {
+    this.copyMode();
+  }
+
+  copyMode() {
+    const cur = this.editor.vortex.engine().modes().curMode();
+    if (!cur) {
+      Notification.failure("No mode to copy");
       return;
     }
     const modeData = this.editor.vortex.printModeJson(false);
@@ -346,19 +353,269 @@ export default class ModesPanel extends Panel {
     });
   }
 
-  // Paste copied mode data
+  copyColorset() {
+    const cur = this.editor.vortex.engine().modes().curMode();
+    if (!cur) return;
+
+    const mainLed = this.editor.ledSelectPanel.getMainSelectedLed();
+    if (mainLed === null) {
+      Notification.failure("Select an LED first");
+      return;
+    }
+
+    const set = cur.getColorset(mainLed);
+    const colors = [];
+    for (let i = 0; i < set.numColors(); i++) {
+      const col = set.get(i);
+      const hex = `#${((1 << 24) + (col.red << 16) + (col.green << 8) + col.blue).toString(16).slice(1).toUpperCase()}`;
+      colors.push(hex);
+    }
+
+    const data = JSON.stringify({ type: "colorset", colors });
+    navigator.clipboard.writeText(data).then(() => {
+      Notification.success("Copied colorset to clipboard");
+    }).catch(() => {
+      Notification.failure("Failed to copy colorset");
+    });
+  }
+
+  copyPattern() {
+    const cur = this.editor.vortex.engine().modes().curMode();
+    if (!cur) return;
+
+    const mainLed = this.editor.ledSelectPanel.getMainSelectedLed();
+    if (mainLed === null) {
+      Notification.failure("Select an LED first");
+      return;
+    }
+
+    const patID = cur.getPatternID(mainLed);
+    const set = cur.getColorset(mainLed);
+    const colors = [];
+    for (let i = 0; i < set.numColors(); i++) {
+      const col = set.get(i);
+      const hex = `#${((1 << 24) + (col.red << 16) + (col.green << 8) + col.blue).toString(16).slice(1).toUpperCase()}`;
+      colors.push(hex);
+    }
+
+    const args = [];
+    for (let i = 0; i < 7; i++) {
+      args.push(cur.getArg(i, mainLed) || 0);
+    }
+
+    const data = JSON.stringify({
+      type: "pattern",
+      pattern_id: patID.value,
+      args
+    });
+    navigator.clipboard.writeText(data).then(() => {
+      Notification.success("Copied pattern to clipboard");
+    }).catch(() => {
+      Notification.failure("Failed to copy pattern");
+    });
+  }
+
+  static detectClipboardData(data) {
+    if (/^#?[0-9A-Fa-f]{6}$/.test(data)) {
+      return { type: 'color', value: data };
+    }
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed && parsed.type === 'colorset' && Array.isArray(parsed.colors)) {
+        return { type: 'colorset', value: parsed };
+      }
+      if (parsed && parsed.type === 'pattern' && parsed.pattern_id !== undefined) {
+        return { type: 'pattern', value: parsed };
+      }
+      if (parsed && (parsed.single_pats || parsed.multi_pat)) {
+        return { type: 'mode', value: parsed };
+      }
+      return { type: 'unknown', value: parsed };
+    } catch {
+      return { type: 'unknown', value: data };
+    }
+  }
+
+  // Paste copied data - intelligently handles all formats
   paste() {
     navigator.clipboard.readText().then((data) => {
-      if (/^#?[0-9A-Fa-f]{6}$/.test(data)) {
+      this.pasteText(data);
+    }).catch(() => {
+      Notification.failure("Failed to read clipboard");
+    });
+  }
+
+  pasteText(data) {
+    if (!data) return;
+    const detected = ModesPanel.detectClipboardData(data);
+    switch (detected.type) {
+      case 'color':
         if (this.editor.colorsetPanel) {
           this.editor.colorsetPanel.paste();
-          return;
         }
-      }
-      this.importModeFromData(JSON.parse(data), true);
-    }).catch(() => {
-      Notification.failure("Failed to paste mode");
+        break;
+      case 'colorset':
+        this.pasteColorset(detected.value);
+        break;
+      case 'pattern':
+        this.pastePattern(detected.value);
+        break;
+      case 'mode':
+        this.importModeFromData(detected.value, true);
+        break;
+      default:
+        try {
+          this.decodeAndImportMode(data, true);
+        } catch {
+          Notification.failure("Unrecognized clipboard data");
+        }
+    }
+  }
+
+  pasteColorset(data) {
+    const cur = this.editor.vortex.engine().modes().curMode();
+    if (!cur) return;
+
+    const mainLed = this.editor.ledSelectPanel.getMainSelectedLed();
+    if (mainLed === null) {
+      Notification.failure("Select an LED first");
+      return;
+    }
+
+    const set = new this.editor.vortexLib.Colorset();
+    data.colors.forEach(hex => {
+      const h = hex.replace(/^#/, '');
+      const bigint = parseInt(h, 16);
+      set.addColor(new this.editor.vortexLib.RGBColor(
+        (bigint >> 16) & 255,
+        (bigint >> 8) & 255,
+        bigint & 255
+      ));
     });
+
+    const targetLeds = this.editor.ledSelectPanel.getSelectedLeds();
+    targetLeds.forEach(led => cur.setColorset(set, led));
+    cur.init();
+    this.editor.vortex.engine().modes().saveCurMode();
+    this.editor.colorsetPanel.refresh();
+    this.editor.demoModeOnDevice();
+    Notification.success("Pasted colorset");
+  }
+
+  pastePattern(data) {
+    const cur = this.editor.vortex.engine().modes().curMode();
+    if (!cur) return;
+
+    const mainLed = this.editor.ledSelectPanel.getMainSelectedLed();
+    if (mainLed === null) {
+      Notification.failure("Select an LED first");
+      return;
+    }
+
+    const patID = this.editor.vortexLib.intToPatternID(data.pattern_id);
+    const args = new this.editor.vortexLib.PatternArgs();
+    data.args.forEach(arg => args.addArgs(arg));
+
+    const targetLeds = this.editor.ledSelectPanel.getSelectedLeds();
+    targetLeds.forEach(led => {
+      const colorset = data.colorset
+        ? (() => {
+            const set = new this.editor.vortexLib.Colorset();
+            data.colorset.forEach(hex => {
+              const h = hex.replace(/^#/, '');
+              const bigint = parseInt(h, 16);
+              set.addColor(new this.editor.vortexLib.RGBColor(
+                (bigint >> 16) & 255,
+                (bigint >> 8) & 255,
+                bigint & 255
+              ));
+            });
+            return set;
+          })()
+        : cur.getColorset(led);
+      cur.setPattern(patID, led, args, colorset);
+    });
+    cur.init();
+    this.editor.vortex.engine().modes().saveCurMode();
+    this.refresh();
+    this.editor.patternPanel.refresh();
+    this.editor.colorsetPanel.refresh();
+    this.editor.demoModeOnDevice();
+    Notification.success("Pasted pattern");
+  }
+
+  getCopyOptions() {
+    const options = [];
+    const cur = this.editor.vortex.engine().modes().curMode();
+    if (!cur) return options;
+
+    options.push({
+      label: 'Copy Mode',
+      action: () => this.copyMode()
+    });
+
+    const mainLed = this.editor.ledSelectPanel.getMainSelectedLed();
+    if (mainLed !== null) {
+      options.push({ separator: true });
+      options.push({
+        label: 'Copy Colorset',
+        action: () => this.copyColorset()
+      });
+      options.push({
+        label: 'Copy Pattern',
+        action: () => this.copyPattern()
+      });
+    }
+
+    return options;
+  }
+
+  getContextMenuItems() {
+    const items = [];
+    const cur = this.editor.vortex.engine().modes().curMode();
+    if (cur) {
+      items.push({
+        label: 'Copy Mode',
+        action: () => this.copyMode()
+      });
+      const mainLed = this.editor.ledSelectPanel.getMainSelectedLed();
+      if (mainLed !== null) {
+        items.push({
+          label: 'Copy Colorset',
+          action: () => this.copyColorset()
+        });
+        items.push({
+          label: 'Copy Pattern',
+          action: () => this.copyPattern()
+        });
+      }
+      items.push({ separator: true });
+      items.push({
+        label: 'Get Link',
+        action: () => this.showLinkModeModal()
+      });
+      items.push({
+        label: 'Share Mode',
+        action: () => this.shareModeToCommunity()
+      });
+      items.push({ separator: true });
+      items.push({
+        label: 'Paste',
+        action: () => this.paste()
+      });
+      items.push({ separator: true });
+      items.push({
+        label: 'Delete Mode',
+        danger: true,
+        action: () => this.deleteMode(this.editor.vortex.curModeIndex())
+      });
+      items.push({ separator: true });
+    }
+    items.push({
+      label: 'Help',
+      action: () => this.editor && this.editor.showHelpPopup(this.wikiUrl)
+    });
+    return items;
   }
 
   attachModeEventListeners() {

--- a/js/Panel.js
+++ b/js/Panel.js
@@ -1,4 +1,6 @@
 /* Panel.js */
+import ContextMenu from './ContextMenu.js';
+
 export default class Panel {
   static panels = []; // Static list to track all panels
   static topZIndex = 3; // Initialize the top Z-Index to the default panel Z-Index
@@ -10,6 +12,8 @@ export default class Panel {
     this.panel.className = 'draggable-panel';
     this.panel.title = title;
     this.panel.editor = editor;
+    this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/';
 
     const { showCloseButton = false } = options;
 
@@ -50,6 +54,15 @@ export default class Panel {
 
     this.initDraggable();
 
+    this.panel.addEventListener('contextmenu', (e) => {
+      const items = this.getContextMenuItems();
+      if (items.length > 0) {
+        e.preventDefault();
+        const menu = ContextMenu.getInstance();
+        menu.show(e.clientX, e.clientY, items);
+      }
+    });
+
     this.initGlobalListeners();
 
     // all panels subscribe to this event?
@@ -68,17 +81,51 @@ export default class Panel {
     Panel.globalListenersInitialized = true;
     document.addEventListener('keydown', (event) => {
       if (event.ctrlKey && event.key === 'c') {
-        if (Panel.selectedPanel && Panel.selectedPanel.canCopy()) {
-          Panel.selectedPanel.copy();
-          event.preventDefault();
-        }
-      } else if (event.ctrlKey && event.key === 'v') {
-        if (Panel.selectedPanel && Panel.selectedPanel.canPaste()) {
-          Panel.selectedPanel.paste();
-          event.preventDefault();
+        event.preventDefault();
+        this.showCopyContextMenu(event);
+      }
+    });
+    document.addEventListener('paste', (event) => {
+      const text = event.clipboardData.getData('text/plain');
+      if (!text) return;
+      event.preventDefault();
+      let handled = false;
+      if (Panel.selectedPanel && Panel.selectedPanel.canPaste()) {
+        Panel.selectedPanel.pasteText(text);
+        handled = true;
+      }
+      if (!handled) {
+        for (const panel of Panel.panels) {
+          if (typeof panel.pasteText === 'function') {
+            panel.pasteText(text);
+            break;
+          }
         }
       }
     });
+  }
+
+  showCopyContextMenu(event) {
+    const menu = ContextMenu.getInstance();
+    const items = [];
+
+    for (const panel of Panel.panels) {
+      if (typeof panel.getCopyOptions === 'function') {
+        const panelOptions = panel.getCopyOptions();
+        if (panelOptions.length > 0) {
+          if (items.length > 0) {
+            items.push({ separator: true });
+          }
+          items.push(...panelOptions);
+        }
+      }
+    }
+
+    if (items.length > 0) {
+      let x = event.clientX || ContextMenu.lastMouseX;
+      let y = event.clientY || ContextMenu.lastMouseY;
+      menu.show(x, y, items);
+    }
   }
 
   // Method to handle selection
@@ -101,6 +148,19 @@ export default class Panel {
   // Copy method to be overridden in derived panels
   copy() {
     console.warn("Copy not implemented for this panel.");
+  }
+
+  // Returns context menu items for copy operations
+  getCopyOptions() {
+    return [];
+  }
+
+  // Returns right-click context menu items for this panel
+  getContextMenuItems() {
+    return [{
+      label: 'Help',
+      action: () => this.editor && this.editor.showHelpPopup(this.wikiUrl)
+    }];
   }
 
   // Paste method to be overridden in derived panels
@@ -250,25 +310,17 @@ export default class Panel {
   }
 
   moveSnappedPanels(heightChange) {
-    const rect = this.panel.getBoundingClientRect();
     const snappedPanels = this.getSnappedPanels();
 
     for (const otherPanel of snappedPanels) {
-      if (otherPanel === this) continue; // Skip self
+      if (otherPanel === this) continue;
 
       const otherRect = otherPanel.panel.getBoundingClientRect();
-
-      // Calculate the new position for the snapped panel
       const currentTop = parseFloat(otherPanel.panel.style.top || otherRect.top);
       const newTop = currentTop + heightChange;
 
-      // Recursively move panels snapped to this one
       otherPanel.moveSnappedPanels(heightChange);
-
       otherPanel.panel.style.top = `${newTop}px`;
-
-      // Return immediately after finding a snapped panel
-      return;
     }
   }
 

--- a/js/PatternPanel.js
+++ b/js/PatternPanel.js
@@ -19,6 +19,7 @@ export default class PatternPanel extends Panel {
     `;
     super(editor, 'patternPanel', content, 'Pattern');
     this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/pattern';
   }
 
   initialize() {

--- a/js/UpdatePanel.js
+++ b/js/UpdatePanel.js
@@ -25,6 +25,7 @@ export default class UpdatePanel extends Panel {
     super(editor, 'updatePanel', content, 'Device Updates', { showCloseButton: true });
 
     this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/update-panel';
     this.vortexPort = editor.vortexPort;
 
     // this.serialPort is a local copy of the vortexport.serialport if it's

--- a/js/VortexEditor.js
+++ b/js/VortexEditor.js
@@ -17,6 +17,7 @@ import DuoEditorPanel from './DuoEditorPanel.js';
 import UpdatePanel from './UpdatePanel.js';
 import Notification from './Notification.js';
 import VortexLib from './VortexLib.js';
+import ContextMenu from './ContextMenu.js';
 import { VERSION } from './version.js';  // Adjust path if needed
 
 import * as BLE from './ble.js'; // Import BLE module
@@ -190,6 +191,56 @@ export default class VortexEditor {
 
     // Handle URL-imported mode data
     this.importModeDataFromUrl();
+
+    // Right-click context menu on canvas
+    this.canvas.addEventListener('contextmenu', (e) => {
+      e.preventDefault();
+      const menu = ContextMenu.getInstance();
+      const items = [];
+      const curMode = this.vortex.engine().modes().curMode();
+
+      if (curMode) {
+        const mainLed = this.ledSelectPanel.getMainSelectedLed();
+        items.push({
+          label: 'Copy Mode',
+          action: () => this.modesPanel.copyMode()
+        });
+        if (mainLed !== null) {
+          items.push({
+            label: 'Copy Colorset',
+            action: () => this.modesPanel.copyColorset()
+          });
+          items.push({
+            label: 'Copy Pattern',
+            action: () => this.modesPanel.copyPattern()
+          });
+        }
+        items.push({ separator: true });
+        items.push({
+          label: 'Get Link',
+          action: () => this.modesPanel.showLinkModeModal()
+        });
+        items.push({
+          label: 'Share Mode',
+          action: () => this.modesPanel.shareModeToCommunity()
+        });
+        items.push({ separator: true });
+      }
+      items.push({
+        label: 'Paste',
+        action: () => this.modesPanel.paste()
+      });
+
+      items.push({ separator: true });
+      items.push({
+        label: 'Help',
+        action: () => this.showHelpPopup()
+      });
+
+      if (items.length > 0) {
+        menu.show(e.clientX, e.clientY, items);
+      }
+    });
 
     // Keydown event to show updatePanel
     document.addEventListener('keydown', async (event) => {
@@ -650,6 +701,45 @@ export default class VortexEditor {
     } catch (error) {
       Notification.failure("Failed to demo mode (" + error + ")");
     }
+  }
+
+  showHelpPopup(url = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/') {
+    const existing = document.querySelector('.help-popup-overlay');
+    if (existing) existing.remove();
+
+    const overlay = document.createElement('div');
+    overlay.className = 'help-popup-overlay';
+
+    const popup = document.createElement('div');
+    popup.className = 'help-popup';
+
+    const header = document.createElement('div');
+    header.className = 'help-popup-header';
+    header.innerHTML = '<span>Help</span><span class="help-popup-close">&times;</span>';
+    header.querySelector('.help-popup-close').onclick = () => overlay.remove();
+
+    const content = document.createElement('div');
+    content.style.cssText = 'flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:32px;color:#e0ddd9;';
+    content.innerHTML = `
+      <p style="margin:0;font-size:15px;text-align:center;opacity:0.85;">
+        Open the wiki page in a new tab to view help documentation.
+      </p>
+      <a href="${url}" target="_blank" rel="noopener"
+         style="display:inline-flex;align-items:center;gap:8px;padding:10px 24px;
+                background:#3a3a3c;color:#e0ddd9;border-radius:6px;
+                text-decoration:none;font-size:15px;font-weight:600;">
+        <i class="fas fa-external-link-alt"></i> Open Wiki
+      </a>
+    `;
+
+    popup.appendChild(header);
+    popup.appendChild(content);
+    overlay.appendChild(popup);
+    document.body.appendChild(overlay);
+
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) overlay.remove();
+    });
   }
 }
 

--- a/js/WelcomePanel.js
+++ b/js/WelcomePanel.js
@@ -1,44 +1,121 @@
 /* WelcomePanel.js */
 import Panel from './Panel.js';
 
+// Newest entries FIRST — add new items at the top so they appear first in the list
+const FEATURES = [
+  { key: 'welcome-panel', html: '<strong>Improved Welcome Panel</strong> — This panel now tracks which updates you\'ve seen. Click entries to mark them as read. View it again next time to see new updates.' },
+  { key: 'context-menus', html: '<strong>Right-click Context Menus</strong> — Right-click anywhere (canvas, panel, color swatch) for instant copy, paste, share, help, and more.' },
+  { key: 'copy-paste', html: '<strong>Smarter Copy & Paste</strong> — Copy modes, colorsets, or patterns. Paste auto-detects whatever is on your clipboard.' },
+  { key: 'wiki-help', html: '<strong>Inline Wiki Help</strong> — Right-click any panel and select <b>Help</b> to open its wiki page right inside the editor as an overlay popup. No tab-switching!' },
+  { key: 'ios-support', html: '<strong>iOS Mobile Support</strong> — iOS users can now connect to devices using a WebBluetooth-enabled browser from the App Store, like Bluefy.' },
+  { key: 'firefox-ui', html: '<strong>Firefox Support & UI Fixes</strong> — Numerous UI bug fixes across the editor. Firefox now supports WebSerial for device connectivity, and major Firefox-specific bugs have been resolved.' },
+  { key: 'wiki-updates', html: '<strong>Wiki Updates</strong> — Several new wiki pages have been added, many existing pages have been improved and refactored, and all broken links have been cleaned up and fixed.' },
+  { key: 'colorset-controls', html: '<strong>Improved Colorset Generator</strong> — Revamped randomization controls: slider + number for color count, style dropdown, and a brightness slider. Old quick-preset buttons removed in favor of a cleaner layout.' },
+];
+
 export default class WelcomePanel extends Panel {
   constructor(editor) {
+    const seen = WelcomePanel.getSeen();
+
+    let featuresHtml = '';
+    for (const f of FEATURES) {
+      const isSeen = seen.has(f.key);
+      const badgeHtml = isSeen ? '' : '<div class="feature-badge pulse">NEW</div>';
+      const seenClass = isSeen ? ' seen' : '';
+      featuresHtml += `
+        <div class="feature-box${seenClass}" data-key="${f.key}">
+          ${badgeHtml}
+          <div>${f.html}</div>
+        </div>`;
+    }
+
     let content = `
-      <h1>Welcome to lightshow.lol</h1>
-      <p>Hello! If you found this website then you're likely a flow artist or glover. If you have no idea what that means, then welcome to your first lightshow!
-      This website is an ongoing development designed for both enjoyment and as a tool to control Vortex Lightshow Devices.</p>
+      <h1 class="welcome-title">Welcome to lightshow.lol</h1>
+      <p class="intro-text">Hello! If you found this website then you're likely a flow artist or glover.</p>
+      <p class="intro-text">If you have no idea what that means, then welcome to your first lightshow!</p>
 
-      <h2>New Updates</h2>
-      <p>Lots of new updates are being deployed lately, explore the new UI and keep an eye out for new features. See the 
-      <a href="https://github.com/Unreal-Dan/lightshow.lol" target="_blank">Github</a> to share suggestions or report any bugs.</p>
+      <div class="features-container">
+        <div class="features-container-title">News & Updates</div>
+        <div class="feature-scroll">
+          ${featuresHtml}
+        </div>
+      </div>
 
-      <h2>The Wiki</h2>
-      <p>If you're new or just want to dive deeper, check out the Vortex Engine Wiki for guides, tips, and instructions:</p>
-      <a href="https://stoneorbits.github.io/VortexEngine/lightshow_lol.html" target="_blank" class="wiki-button">
-        <span>Learn More</span>
+      <a href="https://stoneorbits.github.io/VortexEngine/lightshow-lol/" target="_blank" class="wiki-button">
+        <span>See Wiki</span>
         <span class="arrow">→</span>
       </a>
       <div class="checkbox-container">
-        <label><input type="checkbox" id="doNotShowAgain"> Do not show this again</label>
+        <label><input type="checkbox" id="doNotShowAgain"> Do not show again until next update</label>
       </div>
+      <button class="close-welcome-btn">Close</button>
     `;
 
-
-    //if (editor.detectMobile()) {
-    //  content = `
-    //  <div style="margin: 0 auto;">
-    //    <h1 style="color:orange;text-align:center;">⚠ <b style="color:red;">Warning</b> ⚠<br></h1>
-    //    <h3 style="color:yellow;text-align:center;">The Mobile Layout is under construction!</h3>
-    //  </div>
-    //  ` + content;
-    //}
-
-    super(editor, 'welcomePanel', content, 'Welcome', { showCloseButton: true });
-    this.welcomeToken = 'showNewWelcome';
+    super(editor, 'welcomePanel', content, '', { showCloseButton: true });
+    this.welcomeToken = 'showNewWelcome-v2';
+    localStorage.removeItem('showNewWelcome');
     this.editor = editor;
+    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/getting-started';
+  }
+
+  static getSeen() {
+    try {
+      const raw = localStorage.getItem('seenFeatures');
+      return new Set(raw ? JSON.parse(raw) : []);
+    } catch {
+      return new Set();
+    }
+  }
+
+  static markSeen(key) {
+    const seen = WelcomePanel.getSeen();
+    seen.add(key);
+    localStorage.setItem('seenFeatures', JSON.stringify([...seen]));
+  }
+
+  startAutoScroll() {
+    this.stopAutoScroll();
+    this.scrollInterval = setInterval(() => {
+      if (this.scrollEl) {
+        this.scrollEl.scrollTop += 1;
+      }
+    }, 80);
+  }
+
+  stopAutoScroll() {
+    if (this.scrollInterval) {
+      clearInterval(this.scrollInterval);
+      this.scrollInterval = null;
+    }
   }
 
   initialize() {
+    const boxes = this.panel.querySelectorAll('.feature-box:not(.seen)');
+    for (const box of boxes) {
+      const key = box.dataset.key;
+      box.addEventListener('click', () => {
+        WelcomePanel.markSeen(key);
+        box.classList.add('seen');
+        const badge = box.querySelector('.feature-badge');
+        if (badge) badge.remove();
+      });
+    }
+
+    this.scrollEl = this.panel.querySelector('.feature-scroll');
+    this.scrollInterval = null;
+    this.startAutoScroll();
+
+    this.scrollEl.addEventListener('mouseenter', () => {
+      this.stopAutoScroll();
+      this.scrollEl.scrollTop = 0;
+    });
+    this.scrollEl.addEventListener('mouseleave', () => {
+      this.startAutoScroll();
+    });
+
+    const closeBtn = this.panel.querySelector('.close-welcome-btn');
+    closeBtn.addEventListener('click', () => this.hide());
+
     const doNotShowCheckbox = this.panel.querySelector('#doNotShowAgain');
     doNotShowCheckbox.addEventListener('change', (event) => {
       localStorage.setItem(this.welcomeToken, !event.target.checked);
@@ -58,28 +135,22 @@ export default class WelcomePanel extends Panel {
     const tabContainer = document.querySelector('.mobile-panel-content');
     if (!tabContainer) return;
 
-    // Append the panel to the mobile panel container
     tabContainer.appendChild(this.panel);
 
-    // Remove unnecessary borders and set transparent background
     this.panel.style.border = 'none';
     this.panel.style.backgroundColor = 'transparent';
 
-    // Get the height available for the panel
     const viewportHeight = window.innerHeight;
     const tabContainerRect = tabContainer.getBoundingClientRect();
     const availableHeight = viewportHeight - tabContainerRect.top;
 
-    // Set the panel height to fit the remaining space
     this.panel.style.height = `${availableHeight}px`;
 
-    // Ensure the content container takes up the remaining space inside the panel
     this.contentContainer.style.flex = '1';
     this.contentContainer.style.display = 'flex';
     this.contentContainer.style.flexDirection = 'column';
     this.contentContainer.style.overflowY = 'auto';
 
-    // Ensure the panel is visible
     this.show();
   }
 }


### PR DESCRIPTION
    feat: context menus, redesigned panels, wiki help popup, color picker, and generator improvements
    
    - Add ContextMenu.js singleton component with dark theme styling
    - Add right-click context menu to canvas: Copy Mode/Colorset/Pattern, Get Link, Share Mode, Paste, Help
    - Add right-click context menu to panels: Help with panel-specific wiki URL
    - Add ModesPanel context menu: Copy/Get Link/Share Mode/Paste/Delete Mode (danger), Help
    - Add Paste option to ColorsetPanel color swatch context menu
    - Add help popup overlay with wiki content (external link to avoid cross-origin white flash)
    - Map each panel to its specific wiki URL
    - Replace Ctrl+V keydown handler with native paste event to avoid browser clipboard permission prompt
    - Add pasteText() methods for direct clipboard data handling
    - Fix pattern paste without colorset (keep existing LED colorset)
    - Fix mode list not refreshing after pattern paste
    - Fix Ctrl+C context menu positioning (use last mouse position)
    - Fix delete-mode-btn vertical alignment with flexbox centering
    - Redesign Welcome Panel as "News & Updates" with tracked features, auto-scroll, click-to-dismiss
    - Redesign About Panel with pill buttons (Community, GitHub, Welcome)
    - Add wikiUrl to ColorPickerPanel for context-sensitive help
    - Redesign ColorsetPanel generator: color count slider + number input, style dropdown, brightness slider, Generate button
    - Add custom slider drag handlers for colorset controls (fix browser range-input bugs)
    - Add vibrant/warm/cool/grayscale preset styles
    - Update colorset CSS for generator layout and per-slider track/thumb styling

