### PR TITLE
dev: auto-detect local wiki URL for development testing

### DIFF
--- a/js/AboutPanel.js
+++ b/js/AboutPanel.js
@@ -1,8 +1,8 @@
 import Panel from './Panel.js';
+import { wikiUrl } from './wiki-url.js';
 
 const COMMUNITY_URL = 'https://vortex.community';
 const GITHUB_URL = 'https://github.com/StoneOrbits/VortexEngine';
-const WIKI_URL = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/';
 
 export default class AboutPanel extends Panel {
   constructor(editor) {
@@ -21,7 +21,7 @@ export default class AboutPanel extends Panel {
     `;
     super(editor, 'aboutPanel', content, 'Help & About');
     this.editor = editor;
-    this.wikiUrl = WIKI_URL;
+    this.wikiUrl = wikiUrl('/lightshow-lol/');
     this.lightshow = editor.lightshow;
     this.vortexPort = editor.vortexPort;
   }

--- a/js/AnimationPanel.js
+++ b/js/AnimationPanel.js
@@ -1,4 +1,5 @@
 import Panel from './Panel.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class AnimationPanel extends Panel {
   constructor(editor) {
@@ -98,7 +99,7 @@ export default class AnimationPanel extends Panel {
     super(editor, 'animationPanel', content, 'Animation');
 
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/animation';
+    this.wikiUrl = wikiUrl('/lightshow-lol/control-panels/animation');
     this.lightshow = editor.lightshow;
     this.controls = controls;
     this.isVisible = true;

--- a/js/ChromalinkPanel.js
+++ b/js/ChromalinkPanel.js
@@ -1,6 +1,7 @@
 import Panel from './Panel.js';
 import Notification from './Notification.js';
 import Modal from './Modal.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class ChromalinkPanel extends Panel {
   constructor(editor) {
@@ -29,7 +30,7 @@ export default class ChromalinkPanel extends Panel {
     `;
     super(editor, 'chromalinkPanel', content, 'Chromalink Duo');
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/chromalink-duo';
+    this.wikiUrl = wikiUrl('/lightshow-lol/control-panels/chromalink-duo');
     this.vortexPort = editor.vortexPort;
     this.isConnected = false;
     this.confirmationModal = new Modal('duo-flash-confirmation');

--- a/js/ColorPickerPanel.js
+++ b/js/ColorPickerPanel.js
@@ -1,10 +1,11 @@
 import Panel from './Panel.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class ColorPickerPanel extends Panel {
   constructor(editor) {
     super(editor, 'colorPickerPanel', '', 'Color Picker', { showCloseButton: true }); // Pass id and title to Panel
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/color-picker';
+    this.wikiUrl = wikiUrl('/lightshow-lol/control-panels/color-picker');
     this.lightshow = editor.lightshow;
     this.selectedIndex = 0;
     this.colorState = { r: 255, g: 0, b: 0, h: 0, s: 255, v: 255 };

--- a/js/ColorsetPanel.js
+++ b/js/ColorsetPanel.js
@@ -3,6 +3,7 @@ import Modal from './Modal.js';
 import Notification from './Notification.js';
 import ColorPickerPanel from './ColorPickerPanel.js';
 import ContextMenu from './ContextMenu.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class ColorsetPanel extends Panel {
   constructor(editor) {
@@ -45,7 +46,7 @@ export default class ColorsetPanel extends Panel {
     `;
     super(editor, 'colorsetPanel', content, 'Colorset');
     this.editor = editor
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/colorset';
+    this.wikiUrl = wikiUrl('/lightshow-lol/control-panels/colorset');
     this.lightshow = editor.lightshow;
     this.vortexPort = editor.vortexPort;
     this.selectedColorIndex = null;

--- a/js/CommunityBrowserPanel.js
+++ b/js/CommunityBrowserPanel.js
@@ -1,4 +1,5 @@
 import Panel from './Panel.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class CommunityBrowserPanel extends Panel {
   constructor(editor) {
@@ -20,7 +21,7 @@ export default class CommunityBrowserPanel extends Panel {
     `;
     super(editor, 'communityBrowserPanel', initialHTML, 'Community Modes');
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/vortex-community/';
+    this.wikiUrl = wikiUrl('/vortex-community/');
     this.lightshow = editor.lightshow;
     this.vortexPort = editor.vortexPort;
 

--- a/js/DevicePanel.js
+++ b/js/DevicePanel.js
@@ -1,6 +1,7 @@
 import Panel from './Panel.js';
 import Notification from './Notification.js';
 import Modal from  './Modal.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class DevicePanel extends Panel {
   constructor(editor) {
@@ -51,7 +52,7 @@ export default class DevicePanel extends Panel {
             // </div>
     super(editor, 'devicePanel', content, editor.detectMobile() ? 'Device' : 'Device Controls');
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/device-controls';
+    this.wikiUrl = wikiUrl('/lightshow-lol/control-panels/device-controls');
     this.selectedDevice = 'None';
     this.multiLedWarningModal = new Modal('multiLedWarning');
   }

--- a/js/DuoEditorPanel.js
+++ b/js/DuoEditorPanel.js
@@ -1,4 +1,5 @@
 import Panel from './Panel.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class DuoEditorPanel extends Panel {
   constructor(editor) {
@@ -26,7 +27,7 @@ export default class DuoEditorPanel extends Panel {
     `;
     super(editor, 'duoEditorPanel', content, 'Duo Editor');
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/chromalink-duo';
+    this.wikiUrl = wikiUrl('/lightshow-lol/control-panels/chromalink-duo');
     this.selectedLeds = ['0']; // LED 0 selected by default
     this.mainSelectedLed = '0';
   }

--- a/js/LedSelectPanel.js
+++ b/js/LedSelectPanel.js
@@ -1,6 +1,7 @@
 import Panel from './Panel.js';
 import Modal from './Modal.js';
 import Notification from './Notification.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class LedSelectPanel extends Panel {
   constructor(editor) {
@@ -42,7 +43,7 @@ export default class LedSelectPanel extends Panel {
     `;
     super(editor, 'ledSelectPanel', content, editor.detectMobile() ? 'LEDs' : 'LED Selection');
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/led-selection';
+    this.wikiUrl = wikiUrl('/lightshow-lol/control-panels/led-selection');
   }
 
   initialize() {

--- a/js/ModesPanel.js
+++ b/js/ModesPanel.js
@@ -3,6 +3,7 @@ import Panel from './Panel.js';
 import Modal from './Modal.js';
 import Notification from './Notification.js';
 import ChromalinkPanel from './ChromalinkPanel.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class ModesPanel extends Panel {
   constructor(editor) {
@@ -36,7 +37,7 @@ export default class ModesPanel extends Panel {
     `;
     super(editor, 'modesPanel', content, editor.detectMobile() ? 'Modes' : 'Modes List');
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/modes-list';
+    this.wikiUrl = wikiUrl('/lightshow-lol/control-panels/modes-list');
     this.lightshow = editor.lightshow;
     this.vortexPort = editor.vortexPort;
     this.shareModal = new Modal('share');

--- a/js/Panel.js
+++ b/js/Panel.js
@@ -1,5 +1,6 @@
 /* Panel.js */
 import ContextMenu from './ContextMenu.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class Panel {
   static panels = []; // Static list to track all panels
@@ -13,7 +14,7 @@ export default class Panel {
     this.panel.title = title;
     this.panel.editor = editor;
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/';
+    this.wikiUrl = wikiUrl('/lightshow-lol/');
 
     const { showCloseButton = false } = options;
 

--- a/js/PatternPanel.js
+++ b/js/PatternPanel.js
@@ -1,4 +1,5 @@
 import Panel from './Panel.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class PatternPanel extends Panel {
   constructor(editor) {
@@ -19,7 +20,7 @@ export default class PatternPanel extends Panel {
     `;
     super(editor, 'patternPanel', content, 'Pattern');
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/pattern';
+    this.wikiUrl = wikiUrl('/lightshow-lol/control-panels/pattern');
   }
 
   initialize() {

--- a/js/UpdatePanel.js
+++ b/js/UpdatePanel.js
@@ -3,6 +3,7 @@
 import Panel from './Panel.js';
 import Notification from './Notification.js';
 import Modal from './Modal.js';
+import { wikiUrl } from './wiki-url.js';
 
 export default class UpdatePanel extends Panel {
   constructor(editor) {
@@ -25,7 +26,7 @@ export default class UpdatePanel extends Panel {
     super(editor, 'updatePanel', content, 'Device Updates', { showCloseButton: true });
 
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/control-panels/update-panel';
+    this.wikiUrl = wikiUrl('/lightshow-lol/control-panels/update-panel');
     this.vortexPort = editor.vortexPort;
 
     // this.serialPort is a local copy of the vortexport.serialport if it's
@@ -385,14 +386,14 @@ export default class UpdatePanel extends Panel {
     if (lowerDevice === 'duo') {
       content += `
         <div class="firmware-buttons">
-          <a href="https://stoneorbits.github.io/VortexEngine/${lowerDevice}_upgrade_guide.html" target="_blank" class="btn-upgrade-guide">Read the Upgrade Guide</a>
+          <a href="${wikiUrl('/' + lowerDevice + '_upgrade_guide.html')}" target="_blank" class="btn-upgrade-guide">Read the Upgrade Guide</a>
         </div>
       `;
     } else if (['orbit', 'handle', 'gloves'].includes(lowerDevice)) {
       content += `
         <div class="firmware-buttons">
           <a href="${downloadUrl}" target="_blank" class="btn-download">Download Latest Version</a>
-          <a href="https://stoneorbits.github.io/VortexEngine/${lowerDevice}_upgrade_guide.html" target="_blank" class="btn-upgrade-guide">Read the Upgrade Guide</a>
+          <a href="${wikiUrl('/' + lowerDevice + '_upgrade_guide.html')}" target="_blank" class="btn-upgrade-guide">Read the Upgrade Guide</a>
         </div>
       `;
     } else if (['chromadeck', 'spark'].includes(lowerDevice)) {

--- a/js/VortexEditor.js
+++ b/js/VortexEditor.js
@@ -19,6 +19,7 @@ import Notification from './Notification.js';
 import VortexLib from './VortexLib.js';
 import ContextMenu from './ContextMenu.js';
 import { VERSION } from './version.js';  // Adjust path if needed
+import { wikiUrl } from './wiki-url.js';
 
 import * as BLE from './ble.js'; // Import BLE module
 
@@ -703,7 +704,7 @@ export default class VortexEditor {
     }
   }
 
-  showHelpPopup(url = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/') {
+  showHelpPopup(url = wikiUrl('/lightshow-lol/')) {
     const existing = document.querySelector('.help-popup-overlay');
     if (existing) existing.remove();
 

--- a/js/WelcomePanel.js
+++ b/js/WelcomePanel.js
@@ -1,5 +1,6 @@
 /* WelcomePanel.js */
 import Panel from './Panel.js';
+import { wikiUrl } from './wiki-url.js';
 
 // Newest entries FIRST — add new items at the top so they appear first in the list
 const FEATURES = [
@@ -41,7 +42,7 @@ export default class WelcomePanel extends Panel {
         </div>
       </div>
 
-      <a href="https://stoneorbits.github.io/VortexEngine/lightshow-lol/" target="_blank" class="wiki-button">
+      <a href="${wikiUrl('/lightshow-lol/')}" target="_blank" class="wiki-button">
         <span>See Wiki</span>
         <span class="arrow">→</span>
       </a>
@@ -55,7 +56,7 @@ export default class WelcomePanel extends Panel {
     this.welcomeToken = 'showNewWelcome-v2';
     localStorage.removeItem('showNewWelcome');
     this.editor = editor;
-    this.wikiUrl = 'https://stoneorbits.github.io/VortexEngine/lightshow-lol/getting-started';
+    this.wikiUrl = wikiUrl('/lightshow-lol/getting-started');
   }
 
   static getSeen() {

--- a/js/wiki-url.js
+++ b/js/wiki-url.js
@@ -1,0 +1,13 @@
+const WIKI_PROD = 'https://stoneorbits.github.io/VortexEngine';
+
+function isLocal() {
+  return location.hostname === '127.0.0.1' || location.hostname === 'localhost';
+}
+
+function wikiBase() {
+  return isLocal() ? 'http://127.0.0.1:4000/VortexEngine' : WIKI_PROD;
+}
+
+export function wikiUrl(path = '') {
+  return `${wikiBase()}${path}`;
+}


### PR DESCRIPTION
When running lightshow.lol locally (127.0.0.1 or localhost), all wiki links automatically point to http://127.0.0.1:4000/VortexEngine/ instead of the production GitHub Pages URL.